### PR TITLE
[sc-10234] Support refund when canceling order

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Plugin\Smartpay;
+
+use Exception;
+
+class Client
+{
+    private $secretKey;
+    private $publicKey;
+    private $apiPrefix;
+
+    function __construct($secretKey = null, $publicKey = null, $apiPrefix = null) {
+        $this->secretKey = $secretKey;
+        $this->publicKey = $publicKey;
+        $this->apiPrefix = $apiPrefix;
+
+        if (!$secretKey) {
+            $this->secretKey = getenv('SMARTPAY_SECRET_KEY');
+        }
+        if (!$publicKey) {
+            $this->publicKey = getenv('SMARTPAY_PUBLIC_KEY');
+        }
+        if (!$apiPrefix) {
+            $this->apiPrefix = "https://api.smartpay.co/v1";
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function httpGet($url)
+    {;
+        $curl = $this->curlInit($url);
+        $response = curl_exec($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        curl_close($curl);
+        if ($httpCode != 200) {
+            log_error("[Smartpay] GET ${url} ${httpCode}", array(
+                'response' => $response
+            ));
+            throw new Exception("システム管理者に連絡してください");
+        }
+        return json_decode($response, true);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function httpPost($url, $data)
+    {
+        $curl = $this->curlInit($url);
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+        $response = curl_exec($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+        curl_close($curl);
+        if ($httpCode != 200) {
+            log_error("[Smartpay] POST ${url} ${httpCode}", array(
+                'payload' => $data,
+                'response' => $response
+            ));
+            throw new Exception("システム管理者に連絡してください");
+        }
+        return json_decode($response, true);
+    }
+
+    private function curlInit($url)
+    {
+        $url = $this->apiPrefix . $url;
+        $curl = curl_init($url);
+        $authorization = "Authorization: Basic {$this->secretKey}";
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
+            'Accept: application/json',
+            'Content-Type: application/json',
+            $authorization
+        ));
+        curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate,sdch');
+        return $curl;
+    }
+}

--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -275,12 +275,13 @@ class PaymentController extends AbstractShoppingController
 
             $OrderStatus = $this->orderStatusRepository->find(OrderStatus::NEW);
             $Order->setOrderStatus($OrderStatus);
-
-            $PaymentStatus = $this->paymentStatusRepository->find(PaymentStatus::PROVISIONAL_SALES);
+            $PaymentStatus = $this->paymentStatusRepository->find(PaymentStatus::ACTUAL_SALES);
             $Order->setSmartpayPaymentStatus($PaymentStatus);
 
             $this->purchaseFlow->commit($Order, new PurchaseContext());
             $this->completeShopping($Order);
+            $PaidOrderStatus = $this->orderStatusRepository->find(OrderStatus::PAID);
+            $this->orderRepository->changeStatus($Order->getId(), $PaidOrderStatus);
 
             return $this->redirectToRoute('shopping_complete');
         } catch (\Exception $e) {

--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -24,6 +24,7 @@ use Eccube\Service\CartService;
 use Eccube\Service\MailService;
 use Eccube\Service\OrderHelper;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Plugin\Smartpay\Client;
 use Plugin\Smartpay\Entity\Config;
 use Plugin\Smartpay\Entity\PaymentStatus;
 use Plugin\Smartpay\Repository\ConfigRepository;
@@ -83,6 +84,11 @@ class PaymentController extends AbstractShoppingController
      */
     private $parameterBag;
 
+    /**
+     * @var Client
+     */
+    private $client;
+
     public function __construct(
         CartService $cartService,
         OrderHelper $orderHelper,
@@ -103,6 +109,7 @@ class PaymentController extends AbstractShoppingController
         $this->paymentStatusRepository = $paymentStatusRepository;
         $this->config = $configRepository->get();
         $this->parameterBag = $parameterBag;
+        $this->client = new Client(null, null, $this->config->getAPIPrefix());
     }
 
     /**
@@ -171,9 +178,7 @@ class PaymentController extends AbstractShoppingController
                 return null;
             }
         };
-
         try {
-            $url = "{$this->config->getAPIPrefix()}/checkout-sessions";
             $orderItems = $Order->getOrderItems()->getValues();
             // Sort by \Eccube\Entity\Master\OrderItemType so Product appears before of Charge
             usort($orderItems, function ($a, $b) {
@@ -219,12 +224,15 @@ class PaymentController extends AbstractShoppingController
 
 
 
-            $checkoutSession = $this->httpPost($url, $data);
+            $checkoutSession = $this->client->httpPost("/checkout-sessions", $data);
             $sessionID = $checkoutSession['id'];
             $Order->setSmartpayPaymentCheckoutID($sessionID);
             $this->entityManager->flush();
             return $this->redirect($checkoutSession['url']);
         } catch (\Exception $e) {
+            log_error('create checkoutSession error',
+                [ 'stacktrace' => $e->getTraceAsString(), 'msg' => $e->getMessage()]
+            );
             $this->addError($e->getMessage());
             return $this->redirectToRoute('shopping_error');
         }
@@ -252,8 +260,7 @@ class PaymentController extends AbstractShoppingController
 
             // Check if the payment is actually authorized
             $checkoutSessionID = $Order->getSmartpayPaymentCheckoutID();
-            $url = "{$this->config->getAPIPrefix()}/checkout-sessions/{$checkoutSessionID}?expand=all";
-            $checkoutSession = $this->httpGet($url);
+            $checkoutSession = $this->client->httpGet("/checkout-sessions/{$checkoutSessionID}?expand=all");
             if ($checkoutSession['order']['status'] != 'succeeded') {
                 log_error("Order {$id} found, but Smartpay order status is {$checkoutSession['order']['status']}");
                 $this->addError('受注情報が存在しません');
@@ -328,60 +335,5 @@ class PaymentController extends AbstractShoppingController
         $this->entityManager->flush();
     }
 
-    /**
-     * @throws \Exception
-     */
-    private function httpGet($url)
-    {
-        $secretKey = getenv('SMARTPAY_SECRET_KEY');
-        $curl = curl_init($url);
-        $authorization = "Authorization: Basic {$secretKey}";
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
-            'Accept: application/json',
-            'Content-Type: application/json',
-            $authorization
-        ));
-        curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate,sdch');
-        $response = curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
-        curl_close($curl);
-        if ($httpcode != 200) {
-            log_error("[Smartpay] GET ${url} ${httpcode}", array(
-                'response' => $response
-            ));
-            throw new \Exception("システム管理者に連絡してください");
-        }
-        return json_decode($response, true);
-    }
 
-    /**
-     * @throws \Exception
-     */
-    private function httpPost($url, $data)
-    {
-        $secretKey = getenv('SMARTPAY_SECRET_KEY');
-        $curl = curl_init($url);
-        $authorization = "Authorization: Basic {$secretKey}";
-        curl_setopt($curl, CURLOPT_POST, true);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
-            'Accept: application/json',
-            'Content-Type: application/json',
-            $authorization
-        ));
-        curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate,sdch');
-        $response = curl_exec($curl);
-        $httpcode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
-        curl_close($curl);
-        if ($httpcode != 200) {
-            log_error("[Smartpay] POST ${url} ${httpcode}", array(
-                'payload' => $data,
-                'response' => $response
-            ));
-            throw new \Exception("システム管理者に連絡してください");
-        }
-        return json_decode($response, true);
-    }
 }

--- a/Event.php
+++ b/Event.php
@@ -6,11 +6,16 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Event implements EventSubscriberInterface
 {
+    public function onCancel($event)
+    {
+        $Order = $event->getSubject()->getOrder();
+    }
+
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
-        return [];
+        return ['workflow.order.transition.cancel' => 'onCancel'];
     }
 }

--- a/Event.php
+++ b/Event.php
@@ -54,6 +54,9 @@ class Event implements EventSubscriberInterface
             }
 
             // Refund
+            // We only to automatic capture when checkout, so we just refund the first payment here.
+            // We might need to handle cancel smartpay order & refund multiple payments here
+            // if we support manual capture in the future.
             $data = [
                 'amount' => $checkoutSession['order']['amount'],
                 'currency' => $checkoutSession['order']['currency'],

--- a/Event.php
+++ b/Event.php
@@ -2,13 +2,75 @@
 
 namespace Plugin\Smartpay;
 
+use Plugin\Smartpay\Entity\PaymentStatus;
+use Plugin\Smartpay\Repository\ConfigRepository;
+use Plugin\Smartpay\Repository\PaymentStatusRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 class Event implements EventSubscriberInterface
 {
+
+    private $entityManager;
+    private $paymentStatusRepository;
+    private $config;
+    private $client;
+
+    public function __construct(EntityManagerInterface $entityManager, PaymentStatusRepository $paymentStatusRepository,ConfigRepository $configRepository)
+    {
+        $this->entityManager = $entityManager;
+        $this->paymentStatusRepository = $paymentStatusRepository;
+        $this->config = $configRepository->get();
+        $this->client = new Client(null, null, $this->config->getAPIPrefix());
+    }
+
     public function onCancel($event)
     {
-        $Order = $event->getSubject()->getOrder();
+        log_info("[Smartpay] Cancel order");
+        try {
+
+            $Order = $event->getSubject()->getOrder();
+            $checkoutSessionID = $Order->getSmartpayPaymentCheckoutID();
+
+            // Check if SmartpayPaymentCheckoutID exists
+            if (empty($checkoutSessionID)) {
+                log_info("[Smartpay] Skipping refund, SmartpayPaymentCheckoutId not found.");
+                return;
+            }
+
+            // Check if SmartpayPaymentStatus is refundable
+            if ($Order->getSmartpayPaymentStatus() != $this->paymentStatusRepository->find(PaymentStatus::ACTUAL_SALES) &&
+                $Order->getSmartpayPaymentStatus() != $this->paymentStatusRepository->find(PaymentStatus::PROVISIONAL_SALES)) {
+                log_info("[Smartpay] Skipping refund, SmartpayPaymentStatus is not refundable.");
+                return;
+            }
+
+            // Check if the order is refundable
+            $checkoutSessionID = $Order->getSmartpayPaymentCheckoutID();
+            $checkoutSession = $this->client->httpGet("/checkout-sessions/{$checkoutSessionID}?expand=all");
+            if ($checkoutSession['order']['status'] != 'succeeded') {
+                log_error("[Smartpay] Refund skipped, Smartpay order status is {$checkoutSession['order']['status']}");
+                return;
+            }
+
+            // Refund
+            $data = [
+                'amount' => $checkoutSession['order']['amount'],
+                'currency' => $checkoutSession['order']['currency'],
+                'payment' => $checkoutSession['order']['payments'][0]['id'],
+                'reason' => 'requested_by_customer',
+                'reference' => "{$Order->getId()}"
+            ];
+            $refund = $this->client->httpPost("/refunds", $data);
+            log_info("[Smartpay] Order {$Order->getId()} refunded. Smartpay refund ID: {$refund['id']}");
+
+            // Mark Order.SmartpayPaymentStatus as Cancel
+            $PaymentStatus = $this->paymentStatusRepository->find(PaymentStatus::CANCEL);
+            $Order->setSmartpayPaymentStatus($PaymentStatus);
+            $this->entityManager->flush();
+        } catch (\Exception $e) {
+            log_error('[Smartpay] Refund fail:', [ 'msg' => $e->getMessage()]);
+        }
     }
 
     /**


### PR DESCRIPTION
1. The ec-cube order will be marked as `入金済み` instead of `新規受付` when payment was completed successfully.
2. Add a check for the Smartpay payment status in the callback endpoint.
3. When canceling the order, refund if it's a refundable Smartpay order.

<img width="414" alt="image" src="https://user-images.githubusercontent.com/88208/223677571-c43d9a6a-a0d4-47d3-9251-601771b49304.png">

